### PR TITLE
Removed no-console

### DIFF
--- a/eslintrc.yaml
+++ b/eslintrc.yaml
@@ -241,12 +241,6 @@ rules:
   no-alert:
     - error
 
-  # Disallow console.log
-  no-console:
-    - error
-    - allow:
-        - warn
-
   # Disallow if (true) and if (false)
   no-constant-condition:
     - error


### PR DESCRIPTION
For Node, `console.log()` is a common way to show output to the user or to log stuff. In browsers, this is different, but sometimes still desired.